### PR TITLE
Parse the payload in the envelope after verification

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,23 +36,23 @@ var (
 )
 
 func verify(ctx context.Context, provenancePath, artifactHash, source string) error {
+	rClient, err := rekor.NewClient(defaultRekorAddr)
+	if err != nil {
+		return err
+	}
+
+	// Get Rekor entries corresponding to the binary artifact in the provenance.
+	uuids, err := pkg.GetRekorEntries(rClient, artifactHash)
+	if err != nil {
+		return err
+	}
+
 	provenance, err := os.ReadFile(provenancePath)
 	if err != nil {
 		return fmt.Errorf("os.ReadFile: %w", err)
 	}
 
 	env, err := pkg.EnvelopeFromBytes(provenance)
-	if err != nil {
-		return err
-	}
-
-	rClient, err := rekor.NewClient(defaultRekorAddr)
-	if err != nil {
-		return err
-	}
-
-	// Get Rekor entries corresponding to the binary artifact (matching Subject digest) in the provenance.
-	uuids, err := pkg.GetRekorEntries(rClient, *env, artifactHash)
 	if err != nil {
 		return err
 	}
@@ -69,6 +69,12 @@ func verify(ctx context.Context, provenancePath, artifactHash, source string) er
 		return err
 	}
 
+	// Unpack and verify info in the provenance, including the Subject Digest.
+	if err := pkg.VerifyProvenance(env, artifactHash); err != nil {
+		return err
+	}
+
+	// Verify the workflow identity
 	if err := pkg.VerifyWorkflowIdentity(workflowInfo, source); err != nil {
 		return err
 	}

--- a/pkg/provenance.go
+++ b/pkg/provenance.go
@@ -57,7 +57,7 @@ func EnvelopeFromBytes(payload []byte) (env *dsselib.Envelope, err error) {
 }
 
 // Get SHA256 Subject Digest from the provenance statement.
-func getSha256Digest(env dsselib.Envelope) (string, error) {
+func getSha256Digest(env *dsselib.Envelope) (string, error) {
 	pyld, err := base64.StdEncoding.DecodeString(env.Payload)
 	if err != nil {
 		return "", fmt.Errorf("%w: %s", errorInvalidDssePayload, "decoding payload")
@@ -78,20 +78,10 @@ func getSha256Digest(env dsselib.Envelope) (string, error) {
 }
 
 // GetRekorEntries finds all entry UUIDs by the digest of the artifact binary.
-func GetRekorEntries(rClient *client.Rekor, env dsselib.Envelope, artifactHash string) ([]string, error) {
-	// Get Subject Digest from the provenance statement.
-	hash, err := getSha256Digest(env)
-	if err != nil {
-		return nil, err
-	}
-
-	if !strings.EqualFold(hash, artifactHash) {
-		return nil, errorMismatchHash
-	}
-
+func GetRekorEntries(rClient *client.Rekor, artifactHash string) ([]string, error) {
 	// Use search index to find rekor entry UUIDs that match Subject Digest.
 	params := index.NewSearchIndexParams()
-	params.Query = &models.SearchIndex{Hash: fmt.Sprintf("sha256:%v", hash)}
+	params.Query = &models.SearchIndex{Hash: fmt.Sprintf("sha256:%v", artifactHash)}
 	resp, err := rClient.Index.SearchIndex(params)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", errorRekorSearch, err.Error())
@@ -380,6 +370,19 @@ func VerifyWorkflowIdentity(id *WorkflowIdentity, source string) error {
 	// {org}/{repository}.
 	if !strings.EqualFold(id.CallerRepository, strings.TrimLeft(source, "github.com/")) {
 		return fmt.Errorf("unexpected caller repository, got %s", id.CallerRepository)
+	}
+
+	return nil
+}
+
+func VerifyProvenance(env *dsselib.Envelope, expectedHash string) error {
+	hash, err := getSha256Digest(env)
+	if err != nil {
+		return err
+	}
+
+	if !strings.EqualFold(hash, expectedHash) {
+		return errorMismatchHash
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes https://github.com/gossts/slsa-provenance/issues/7

Parses the payload in the envelope only AFTER signature verification. Use the artifact hash for rekor search.