### PR TITLE
🐛 Replace TrimLeft by TrimPrefix

### DIFF
--- a/pkg/provenance.go
+++ b/pkg/provenance.go
@@ -299,6 +299,7 @@ func FindSigningCertificate(ctx context.Context, uuids []string, dssePayload dss
 		if err != nil {
 			continue
 		}
+
 		co := &cosign.CheckOpts{
 			RootCerts:      fulcio.GetRoots(),
 			CertOidcIssuer: certOidcIssuer,
@@ -378,8 +379,8 @@ func VerifyWorkflowIdentity(id *WorkflowIdentity, source string) error {
 
 	// The caller repository in the x509 extension is not fully qualified. It only contains
 	// {org}/{repository}.
-	if !strings.EqualFold(id.CallerRepository, strings.TrimLeft(source, "github.com/")) {
-		return fmt.Errorf("unexpected caller repository, got %s", id.CallerRepository)
+	if !strings.EqualFold(id.CallerRepository, strings.TrimPrefix(source, "github.com/")) {
+		return fmt.Errorf("unexpected caller repository, got '%s'", id.CallerRepository)
 	}
 
 	return nil


### PR DESCRIPTION
TrimLeft seems to remove all characters present in the second argument. I think what we want is TrimFix.

I stumbled upon this problem by chance when trying to verify a provenance from my test repo called `github.com/test-organization-ls/scorecard`